### PR TITLE
Removed use of deprecated IRQF_DISABLED

### DIFF
--- a/pio-interrupt/gpio_interrupt.c
+++ b/pio-interrupt/gpio_interrupt.c
@@ -58,7 +58,7 @@ static int __init gpio_interrupt_init(void)
 
 	irq_number = gpio_to_irq(gpio_number);
 
-	r = request_irq(irq_number, gpio_isr, IRQF_DISABLED, 0, 0);
+	r = request_irq(irq_number, gpio_isr, 0, 0, 0);
 	if (r) {
 		pr_err("Failure requesting irq %i\n", irq_number);
 		return r;


### PR DESCRIPTION
Removed use of flag IRQF_DISABLED which is NOOP and deprecated since kernel version 2.6.35 and was removed from kernel version 4.1. Kernel patch: https://patchwork.kernel.org/patch/5946431/
